### PR TITLE
refactor: Switch to `rusc_hash::FxHashMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dioxus-shareables"
 authors = ["Tamvana Makuluni"]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "MIT"
 description = "Hooks for sharing structures between components."
@@ -18,6 +18,7 @@ dioxus-git = []
 [dependencies]
 dioxus-core = { package = "dioxus-core", version = "0.2.1" }
 paste = "1"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 dioxus = { package = "dioxus", version = "0.2.4" }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -35,18 +35,18 @@
 //! }
 //! ```
 
+use rustc_hash::FxHashMap;
 use std::{
     cell::{Ref, RefCell, RefMut},
-    collections::HashMap,
     sync::Arc,
 };
 
-type LinkUpdateMap = HashMap<usize, (usize, Arc<dyn Fn()>)>;
+type LinkUpdateMap = FxHashMap<usize, (usize, Arc<dyn Fn()>)>;
 /// The actual shared data.
 pub(crate) struct Link<T>(RefCell<(T, LinkUpdateMap)>);
 impl<T> Link<T> {
     pub(crate) fn new(t: T) -> Self {
-        Self(RefCell::new((t, HashMap::new())))
+        Self(RefCell::new((t, FxHashMap::default())))
     }
     pub(crate) fn add_listener<F: FnOnce() -> Arc<dyn Fn()>>(&self, id: usize, f: F) {
         self.0


### PR DESCRIPTION
This switches from `HashMap<_,_,DefaultHasher>` to `rustc_hash::FxHashMap` for improvements to speed.

Addresses one of the points made in #1.